### PR TITLE
Add tv id as parameter

### DIFF
--- a/src/lgtv_rs232/lgtv.py
+++ b/src/lgtv_rs232/lgtv.py
@@ -185,7 +185,7 @@ class LgTV():
         self._volume = None
         self._muted = None
         self._input = None
-        if 0 <= tv_id <= 100:
+        if 0 <= tv_id <= 99:
            self._id = '%02x' % tv_id
         else:
            self._id = '00'

--- a/src/lgtv_rs232/lgtv.py
+++ b/src/lgtv_rs232/lgtv.py
@@ -179,12 +179,16 @@ class LgTV():
         },
     }
 
-    def __init__(self, path, update=True):
-        # path is a string set to the location of the serial device, 
-        # e.g. "/dev/ttyUSB0"
+    def __init__(self, path, tv_id=0, update=True):
+        # path is a string set to the location of the serial device, e.g. "/dev/ttyUSB0"
+        # id is the tv id whcich can be set in tv options, as defalut value brodcast id is used
         self._volume = None
         self._muted = None
         self._input = None
+        if 0 <= tv_id <= 100:
+           self._id = '%02x' % tv_id
+        else:
+           self._id = '00'
         self._sources = sorted(self._other_data['input'].keys())
         self._ser = serial.Serial(path, timeout=2.0, write_timeout=2.0)
         if update and self.is_on:
@@ -236,7 +240,7 @@ class LgTV():
         # For an explanation of the format of the request, see 
         # http://gscs-b2c.lge.com/downloadFile?fileId=6CNJQR84slwAZdSBiw2DA
         request = bytes(
-            ' '.join((self._commands[command], '01', data)) + '\n',
+            ' '.join((self._commands[command], self._id, data)) + '\n',
             'ascii'
         ) 
 


### PR DESCRIPTION
Rs232 use tv id, this tv id may vary. On my TV I have found bug that blocks me from powering on tv when id is changed to other then initial one. In that case only using broadcast id can power on tv. When I changed tv id back to initial I'm able to power one TV using that id. So adding tv id as parameter seems beneficial. 