### PR TITLE
add wrapper to Serial.close

### DIFF
--- a/src/lgtv_rs232/lgtv.py
+++ b/src/lgtv_rs232/lgtv.py
@@ -277,3 +277,6 @@ class LgTV():
         else:
             self._muted = False
         self._volume = self.request('volume', 'check')
+
+    def __del__(self):
+        self._ser.close()


### PR DESCRIPTION
Having close functionality inside lgTV class will be cleaner solution then importing serial in classes using lgTV module.