### PR TITLE
Remove Unnecessary/Erroneous Newline Suffix

### DIFF
--- a/src/lgtv_rs232/lgtv.py
+++ b/src/lgtv_rs232/lgtv.py
@@ -240,7 +240,7 @@ class LgTV():
         # For an explanation of the format of the request, see 
         # http://gscs-b2c.lge.com/downloadFile?fileId=6CNJQR84slwAZdSBiw2DA
         request = bytes(
-            ' '.join((self._commands[command], self._id, data)) + '\r\n',
+            ' '.join((self._commands[command], self._id, data)) + '\r',
             'ascii'
         ) 
 


### PR DESCRIPTION
Based on the [PDF](https://github.com/zcline91/lgtv-rs232-zcline91/blob/main/src/lgtv_rs232/lgtv.py#L241) referenced in code, the commands are suffixed only with a carriage return (`\r`)) and not also with a newline (`\r\n`).  Some LG TV models may tolerate the extra character, but mine (LG G5) did not.  I suspect that this is the same issue as #5.

```
# Before
$ python
Python 3.13.7 (main, Aug 15 2025, 12:34:02) [GCC 15.2.1 20250813] on l
Type "help", "copyright", "credits" or "license" for more information.
>>> from lgtv_rs232 import LgTV
>>> lgtv = LgTV("/dev/ttyUSB0")
>>> lgtv.is_on
False
>>> lgtv.request("power", "on")
False
>>> lgtv.request("power", "on")
False
>>>
# After
$ python
Python 3.13.7 (main, Aug 15 2025, 12:34:02) [GCC 15.2.1 20250813] on l
Type "help", "copyright", "credits" or "license" for more information.
>>> from lgtv_rs232 import LgTV
>>> lgtv = LgTV("/dev/ttyUSB0")
>>> lgtv.is_on
False
>>> lgtv.request("power", "on")
True
```